### PR TITLE
Update status endpoint from statping to statuspage.io instance

### DIFF
--- a/.github/workflows/openlogin.homepage.yml
+++ b/.github/workflows/openlogin.homepage.yml
@@ -76,4 +76,4 @@ jobs:
           contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "component": { "status": "operational" } }
+            { "component": { "status": "${{ (needs.run-tests.result == 'success' && 'operational') || 'major_outage' }}" } }

--- a/.github/workflows/openlogin.homepage.yml
+++ b/.github/workflows/openlogin.homepage.yml
@@ -76,4 +76,4 @@ jobs:
           contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "component": { "status": "${{ (needs.run-tests.result == 'success' && 'operational') || 'major_outage' }}" } }
+            { "component": { "status": "${{ needs.run-tests.result == 'success' && 'operational' || 'major_outage' }}" } }

--- a/.github/workflows/openlogin.homepage.yml
+++ b/.github/workflows/openlogin.homepage.yml
@@ -70,9 +70,10 @@ jobs:
       - name: Update status
         uses: fjogeleit/http-request-action@master
         with:
-          url: https://torusstatus.com/api/services/${{ env.STATUS_SERVICE_ID }}
-          bearerToken: ${{ secrets.STATUS_API_TOKEN }}
+          url: https://api.statuspage.io/v1/pages/${{ secrets.PAGE_ID }}/components/${{ secrets.HOME_PAGE_COMPONENT_ID }}
+          customHeaders: '{ "Authorization": "OAuth ${{ secrets.STATUS_PAGE_API_KEY }}" }'
           method: PATCH
+          contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "online": ${{ needs.run-tests.result == 'success' }} }
+            { "component": { "status": "operational" } }

--- a/.github/workflows/openlogin.login-with-discord.yml
+++ b/.github/workflows/openlogin.login-with-discord.yml
@@ -90,4 +90,4 @@ jobs:
           contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "component": { "status": "${{ (needs.run-tests.result == 'success' && 'operational') || 'major_outage' }}" } }
+            { "component": { "status": "${{ needs.run-tests.result == 'success' && 'operational' || 'major_outage' }}" } }

--- a/.github/workflows/openlogin.login-with-discord.yml
+++ b/.github/workflows/openlogin.login-with-discord.yml
@@ -90,4 +90,4 @@ jobs:
           contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "component": { "status": "operational" } }
+            { "component": { "status": "${{ (needs.run-tests.result == 'success' && 'operational') || 'major_outage' }}" } }

--- a/.github/workflows/openlogin.login-with-discord.yml
+++ b/.github/workflows/openlogin.login-with-discord.yml
@@ -84,9 +84,10 @@ jobs:
       - name: Update status
         uses: fjogeleit/http-request-action@master
         with:
-          url: https://torusstatus.com/api/services/${{ env.STATUS_SERVICE_ID }}
-          bearerToken: ${{ secrets.STATUS_API_TOKEN }}
+          url: https://api.statuspage.io/v1/pages/${{ secrets.PAGE_ID }}/components/${{ secrets.DISCORD_COMPONENT_ID }}
+          customHeaders: '{ "Authorization": "OAuth ${{ secrets.STATUS_PAGE_API_KEY }}" }'
           method: PATCH
+          contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "online": ${{ needs.run-tests.result == 'success' }} }
+            { "component": { "status": "operational" } }

--- a/.github/workflows/openlogin.login-with-facebook.yml
+++ b/.github/workflows/openlogin.login-with-facebook.yml
@@ -90,4 +90,4 @@ jobs:
           contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "component": { "status": "${{ (needs.run-tests.result == 'success' && 'operational') || 'major_outage' }}" } }
+            { "component": { "status": "${{ needs.run-tests.result == 'success' && 'operational' || 'major_outage' }}" } }

--- a/.github/workflows/openlogin.login-with-facebook.yml
+++ b/.github/workflows/openlogin.login-with-facebook.yml
@@ -90,4 +90,4 @@ jobs:
           contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "component": { "status": "operational" } }
+            { "component": { "status": "${{ (needs.run-tests.result == 'success' && 'operational') || 'major_outage' }}" } }

--- a/.github/workflows/openlogin.login-with-facebook.yml
+++ b/.github/workflows/openlogin.login-with-facebook.yml
@@ -84,9 +84,10 @@ jobs:
       - name: Update status
         uses: fjogeleit/http-request-action@master
         with:
-          url: https://torusstatus.com/api/services/${{ env.STATUS_SERVICE_ID }}
-          bearerToken: ${{ secrets.STATUS_API_TOKEN }}
+          url: https://api.statuspage.io/v1/pages/${{ secrets.PAGE_ID }}/components/${{ secrets.FACEBOOK_COMPONENT_ID }}
+          customHeaders: '{ "Authorization": "OAuth ${{ secrets.STATUS_PAGE_API_KEY }}" }'
           method: PATCH
+          contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "online": ${{ needs.run-tests.result == 'success' }} }
+            { "component": { "status": "operational" } }

--- a/.github/workflows/openlogin.login-with-google.yml
+++ b/.github/workflows/openlogin.login-with-google.yml
@@ -90,4 +90,4 @@ jobs:
           contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "component": { "status": "${{ (needs.run-tests.result == 'success' && 'operational') || 'major_outage' }}" } }
+            { "component": { "status": "${{ needs.run-tests.result == 'success' && 'operational' || 'major_outage' }}" } }

--- a/.github/workflows/openlogin.login-with-google.yml
+++ b/.github/workflows/openlogin.login-with-google.yml
@@ -90,4 +90,4 @@ jobs:
           contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "component": { "status": "operational" } }
+            { "component": { "status": "${{ (needs.run-tests.result == 'success' && 'operational') || 'major_outage' }}" } }

--- a/.github/workflows/openlogin.login-with-google.yml
+++ b/.github/workflows/openlogin.login-with-google.yml
@@ -84,9 +84,10 @@ jobs:
       - name: Update status
         uses: fjogeleit/http-request-action@master
         with:
-          url: https://torusstatus.com/api/services/${{ env.STATUS_SERVICE_ID }}
-          bearerToken: ${{ secrets.STATUS_API_TOKEN }}
+          url: https://api.statuspage.io/v1/pages/${{ secrets.PAGE_ID }}/components/${{ secrets.GOOGLE_COMPONENT_ID }}
+          customHeaders: '{ "Authorization": "OAuth ${{ secrets.STATUS_PAGE_API_KEY }}" }'
           method: PATCH
+          contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "online": ${{ needs.run-tests.result == 'success' }} }
+            { "component": { "status": "operational" } }

--- a/.github/workflows/openlogin.login-with-passwordless.yml
+++ b/.github/workflows/openlogin.login-with-passwordless.yml
@@ -89,4 +89,4 @@ jobs:
           contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "component": { "status": "operational" } }
+            { "component": { "status": "${{ (needs.run-tests.result == 'success' && 'operational') || 'major_outage' }}" } }

--- a/.github/workflows/openlogin.login-with-passwordless.yml
+++ b/.github/workflows/openlogin.login-with-passwordless.yml
@@ -83,9 +83,10 @@ jobs:
       - name: Update status
         uses: fjogeleit/http-request-action@master
         with:
-          url: https://torusstatus.com/api/services/${{ env.STATUS_SERVICE_ID }}
-          bearerToken: ${{ secrets.STATUS_API_TOKEN }}
+          url: https://api.statuspage.io/v1/pages/${{ secrets.PAGE_ID }}/components/${{ secrets.PASSWORDLESS_COMPONENT_ID }}
+          customHeaders: '{ "Authorization": "OAuth ${{ secrets.STATUS_PAGE_API_KEY }}" }'
           method: PATCH
+          contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "online": ${{ needs.run-tests.result == 'success' }} }
+            { "component": { "status": "operational" } }

--- a/.github/workflows/openlogin.login-with-passwordless.yml
+++ b/.github/workflows/openlogin.login-with-passwordless.yml
@@ -89,4 +89,4 @@ jobs:
           contentType: 'application/json'
           timeout: 10000
           data: >-
-            { "component": { "status": "${{ (needs.run-tests.result == 'success' && 'operational') || 'major_outage' }}" } }
+            { "component": { "status": "${{ needs.run-tests.result == 'success' && 'operational' || 'major_outage' }}" } }


### PR DESCRIPTION
## Ticket Link
https://toruslabs.atlassian.net/browse/FD-493
## What does this PR do?
Updates the endpoint for signaling test status from statping to statuspage.io
## How to deploy
Add the following secrets:
- STATUS_PAGE_API_KEY
- PAGE_ID
- HOME_PAGE_COMPONENT_ID
- GOOGLE_COMPONENT_ID
- PASSWORDLESS_COMPONENT_ID
- FACEBOOK_COMPONENT_ID
- DISCORD_COMPONENT_ID