### PR TITLE
Delete current device share after fb+2fa flow

### DIFF
--- a/.github/workflows/openlogin.login-with-facebook-2fa.yml
+++ b/.github/workflows/openlogin.login-with-facebook-2fa.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - browser: chromium
+          - browser: firefox
             os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/index.utils.ts
+++ b/index.utils.ts
@@ -132,3 +132,10 @@ export async function confirmEmail({
     await page.close();
   }
 }
+
+export async function deleteCurrentDeviceShare (page: Page) {
+  await Promise.all([
+    page.click('[aria-label="delete device share"]:right-of(:text("current"))'),
+    page.waitForSelector('text=Device share successfully deleted')
+  ])
+}

--- a/openlogin/login-with-facebook-2fa/index.config.ts
+++ b/openlogin/login-with-facebook-2fa/index.config.ts
@@ -8,8 +8,8 @@ import indexConfig from "../../index.config";
 import { readFileSync } from "fs";
 
 const user = {
-  email: "chdrotfhac_1624264537@tfbnw.net",
-  name: "Jennifer",
+  email: "pfhqffxzrq_1640060261@tfbnw.net",
+  name: "Lisa",
   backupPhrase: readFileSync(path.resolve(__dirname, "backup-phrase.txt")).toString()
 }
 
@@ -17,7 +17,7 @@ const projects: Array<
   Pick<PlaywrightWorkerOptions, "browserName"> & Omit<TestArgs, "openloginURL">
 > = [
   {
-    browserName: "chromium",
+    browserName: "firefox",
     user
   }
 ];

--- a/openlogin/login-with-facebook-2fa/index.test.ts
+++ b/openlogin/login-with-facebook-2fa/index.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 import { test } from "./index.lib";
-import { signInWithFacebook } from "../../index.utils";
+import { deleteCurrentDeviceShare, signInWithFacebook } from "../../index.utils";
 
 test("Login with Facebook+2FA", async ({ page, openloginURL, user }) => {
   await page.goto(openloginURL);
@@ -23,6 +23,13 @@ test("Login with Facebook+2FA", async ({ page, openloginURL, user }) => {
   // Go to Account page
   await Promise.all([page.waitForNavigation(), page.click("text=Account")]);
   expect(await page.isVisible(`text=${user.email}`)).toBeTruthy();
+
+  /**
+   * Delete current device share
+   * This prevents new device shares being added on every test run,
+   * slowing down our tests
+   */
+  await deleteCurrentDeviceShare(page)
 
   // Logout
   await Promise.all([page.waitForNavigation(), page.click("text=Logout")]);


### PR DESCRIPTION
## Ticket Link
https://toruslabs.atlassian.net/browse/FD-554
## What does this PR do?
To prevent accumulation of shares causing tests to become progressively slower over time, delete the newly created current device share at the end of the test.