### PR TITLE
Fix fb + 2fa flow failing due to excessive shares

### DIFF
--- a/openlogin/login-with-facebook-2fa/index.config.ts
+++ b/openlogin/login-with-facebook-2fa/index.config.ts
@@ -8,8 +8,8 @@ import indexConfig from "../../index.config";
 import { readFileSync } from "fs";
 
 const user = {
-  email: "pfhqffxzrq_1640060261@tfbnw.net",
-  name: "Lisa",
+  email: "hosdyduxvg_1640060261@tfbnw.net",
+  name: "Sharon",
   backupPhrase: readFileSync(path.resolve(__dirname, "backup-phrase.txt")).toString()
 }
 


### PR DESCRIPTION
## Ticket Link
https://toruslabs.atlassian.net/browse/FD-553
## What does this PR do?
Temporarily fixes fb + 2fa flow failing due to excessive share accumulation. Uses a brand new bot user with no shares.