### PR TITLE
fix: fixed broken facebook 2fa test

### DIFF
--- a/.github/workflows/openlogin.login-with-facebook-2fa.yml
+++ b/.github/workflows/openlogin.login-with-facebook-2fa.yml
@@ -2,7 +2,7 @@ name: OpenLogin - Facebook with 2fa Login
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "*/20 * * * *"
   workflow_dispatch:
 
 env:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ End-to-end testing of [Torus] products.
 
 [![OpenLogin - Facebook Login](https://github.com/torusresearch/torus-e2e-tests/actions/workflows/openlogin.login-with-facebook.yml/badge.svg)](https://github.com/torusresearch/torus-e2e-tests/actions/workflows/openlogin.login-with-facebook.yml)
 
+[![OpenLogin - Facebook Login 2FA](https://github.com/torusresearch/torus-e2e-tests/actions/workflows/openlogin.login-with-facebook-2fa.yml/badge.svg)](https://github.com/torusresearch/torus-e2e-tests/actions/workflows/openlogin.login-with-facebook-2fa.yml)
+
 [![OpenLogin - Discord Login](https://github.com/torusresearch/torus-e2e-tests/actions/workflows/openlogin.login-with-discord.yml/badge.svg)](https://github.com/torusresearch/torus-e2e-tests/actions/workflows/openlogin.login-with-discord.yml)
 
 [![OpenLogin - Passwordless Login](https://github.com/torusresearch/torus-e2e-tests/actions/workflows/openlogin.login-with-passwordless.yml/badge.svg)](https://github.com/torusresearch/torus-e2e-tests/actions/workflows/openlogin.login-with-passwordless.yml)

--- a/openlogin/login-with-facebook-2fa/index.test.ts
+++ b/openlogin/login-with-facebook-2fa/index.test.ts
@@ -17,7 +17,7 @@ test("Login with Facebook+2FA", async ({ page, openloginURL, user }) => {
   await page.click('button:has-text("Confirm")');
 
   await page.waitForURL(`${openloginURL}/wallet/home`, {
-    timeout: 2 * 60 * 1000,
+    timeout: 5 * 60 * 1000,
   });
 
   // Go to Account page
@@ -29,7 +29,7 @@ test("Login with Facebook+2FA", async ({ page, openloginURL, user }) => {
    * This prevents new device shares being added on every test run,
    * slowing down our tests
    */
-  await deleteCurrentDeviceShare(page)
+  await deleteCurrentDeviceShare(page);
 
   // Logout
   await Promise.all([page.waitForNavigation(), page.click("text=Logout")]);

--- a/openlogin/login-with-facebook-2fa/index.test.ts
+++ b/openlogin/login-with-facebook-2fa/index.test.ts
@@ -3,6 +3,8 @@ import { test } from "./index.lib";
 import { deleteCurrentDeviceShare, signInWithFacebook } from "../../utils";
 
 test("Login with Facebook+2FA", async ({ page, openloginURL, user }) => {
+  test.setTimeout(process.env.CI ? 15 * 60 * 1000 : 0);
+
   await page.goto(openloginURL);
   await page.click('button:has-text("Get Started")');
   await page.click('[aria-label="login with facebook"]');
@@ -17,7 +19,7 @@ test("Login with Facebook+2FA", async ({ page, openloginURL, user }) => {
   await page.click('button:has-text("Confirm")');
 
   await page.waitForURL(`${openloginURL}/wallet/home`, {
-    timeout: 5 * 60 * 1000,
+    timeout: 10 * 60 * 1000,
   });
 
   // Go to Account page

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -84,11 +84,12 @@ async function signInWithDiscord(page: Page): Promise<boolean> {
   }
 }
 
-async function deleteCurrentDeviceShare (page: Page) {
+async function deleteCurrentDeviceShare(page: Page) {
   await Promise.all([
     page.click('[aria-label="delete device share"]:right-of(:text("current"))'),
-    page.waitForSelector('text=Device share successfully deleted')
-  ])
+    page.click('button:has-text("Remove share")'),
+    page.waitForSelector("text=Device share successfully deleted"),
+  ]);
 }
 
 export {
@@ -97,5 +98,5 @@ export {
   signInWithFacebook,
   signInWithDiscord,
   confirmEmail,
-  deleteCurrentDeviceShare
-}
+  deleteCurrentDeviceShare,
+};


### PR DESCRIPTION
- fixed broken facebook-2fa test, after clicking delete icon for device share, a confirmation pop was to be handled
- raised timeout for backup phrase verification 